### PR TITLE
bower.json points to dist/ instead of lib/

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "react-codemirror",
   "version": "0.1.0",
   "description": "React Codemirror",
-  "main": "dist/codemirror.min.js",
+  "main": "lib/Codemirror.js",
   "homepage": "https://github.com/JedWatson/react-codemirror",
   "authors": [
     "Jed Watson"


### PR DESCRIPTION
main should probably point to lib/Codemirror.js, the untranspiled version of the react codemirror plugin.

Also the version in bower.json wasn't bumped during the last release (0.1.1)