### PR TITLE
Eliminate React version mismatch pitfall

### DIFF
--- a/lib/Codemirror.js
+++ b/lib/Codemirror.js
@@ -21,7 +21,8 @@ var CodeMirror = React.createClass({
 	},
 
 	componentDidMount: function componentDidMount() {
-		this.codeMirror = CM.fromTextArea(this.refs.codemirror.getDOMNode(), this.props.options);
+		var textareaNode = React.findDOMNode(this.refs.textarea);
+		this.codeMirror = CM.fromTextArea(textareaNode, this.props.options);
 		this.codeMirror.on('change', this.codemirrorValueChanged);
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
@@ -72,7 +73,7 @@ var CodeMirror = React.createClass({
 		return React.createElement(
 			'div',
 			{ className: className },
-			React.createElement('textarea', { ref: 'codemirror', name: this.props.path, defaultValue: this.props.value, autoComplete: 'off' })
+			React.createElement('textarea', { ref: 'textarea', name: this.props.path, defaultValue: this.props.value, autoComplete: 'off' })
 		);
 	}
 

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
   },
   "dependencies": {
     "classnames": "^2.1.2",
-    "codemirror": "^5.3.0",
-    "react": "^0.13.3"
+    "codemirror": "^5.3.0"
   },
   "devDependencies": {
     "gulp": "^3.8.11",
     "happiness": "^1.0.5",
     "react-component-gulp-tasks": "^0.7.0"
+  },
+  "peerDependencies": {
+    "react": "^0.13 - ^0.14.0-beta"
   },
   "browserify-shim": {
     "react": "global:React"

--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -18,7 +18,8 @@ var CodeMirror = React.createClass({
 	},
 
 	componentDidMount () {
-		this.codeMirror = CM.fromTextArea(this.refs.codemirror.getDOMNode(), this.props.options);
+		var textareaNode = React.findDOMNode(this.refs.textarea);
+		this.codeMirror = CM.fromTextArea(textareaNode, this.props.options);
 		this.codeMirror.on('change', this.codemirrorValueChanged);
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
@@ -68,7 +69,7 @@ var CodeMirror = React.createClass({
 		}
 		return (
 			<div className={className}>
-				<textarea ref="codemirror" name={this.props.path} defaultValue={this.props.value} autoComplete="off" />
+				<textarea ref="textarea" name={this.props.path} defaultValue={this.props.value} autoComplete="off" />
 			</div>
 		);
 	}


### PR DESCRIPTION
Let's say that I'm using React 0.14 in my app. Since this component specifies 0.13 in its `package.json` it will be built with a different version/instance of React than its parent. This will lead to puzzling errors, like #7.

This PR moves React to peerDependencies, and makes it compatible with every version of 0.13 and 0.14.