### PR TITLE
Allow all of React 0.13 and all of 0.14 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react-component-gulp-tasks": "^0.7.0"
   },
   "peerDependencies": {
-    "react": "^0.13.3"
+    "react": "^0.13 || ^0.14.0-beta"
   },
   "browserify-shim": {
     "react": "global:React"


### PR DESCRIPTION
Sorry. I got this wrong in #9. This is the right semver string to match all of 0.13 and all of 0.14, including betas. Test it here: http://semver.npmjs.com/