### PR TITLE
add autoSave property

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ React.render(<App />, document.getElementById('app'));
 * `options` `Object (newValue)` options passed to the CodeMirror instance
 * `onChange` `Function (newValue)` called when a change is made
 * `onFocusChange` `Function (focused)` called when the editor is focused or loses focus
+* `autoSave` `Boolean` automatically persist changes to underlying textarea (default false)
 
 See the [CodeMirror API Docs](https://codemirror.net/doc/manual.html#api) for the available options.
 

--- a/lib/Codemirror.js
+++ b/lib/Codemirror.js
@@ -13,7 +13,8 @@ var CodeMirror = React.createClass({
 		options: React.PropTypes.object,
 		path: React.PropTypes.string,
 		value: React.PropTypes.string,
-		className: React.PropTypes.any
+		className: React.PropTypes.any,
+		autoSave: React.PropTypes.bool
 	},
 
 	getInitialState: function getInitialState() {
@@ -72,6 +73,9 @@ var CodeMirror = React.createClass({
 	codemirrorValueChanged: function codemirrorValueChanged(doc, change) {
 		var newValue = doc.getValue();
 		this._currentCodemirrorValue = newValue;
+		if (this.props.autoSave) {
+			this.getCodeMirror().save();
+		}
 		this.props.onChange && this.props.onChange(newValue);
 	},
 


### PR DESCRIPTION
The autoSave property will persist every CodeMirror change to the
underlying text area by repeatedly calling codemirror.save().

This fixes an issue where a user will submit the form and expect the
current codemirror text to submit as the textarea value but due to some
quirk or unclear behavior, the textarea value is not set by the time an
onSubmit handler is triggered.
