### PR TITLE
Remove state from CodeMirror component and limit calls to setState

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "classnames": "^2.2.3",
-    "codemirror": "^5.10.0"
+    "codemirror": "^5.10.0",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -6,6 +6,7 @@ if (typeof navigator !== 'undefined') {
 
 const React = require('react');
 const className = require('classnames');
+const _ = require('underscore');
 
 const CodeMirror = React.createClass({
 	propTypes: {
@@ -27,8 +28,7 @@ const CodeMirror = React.createClass({
 		this.codeMirror.on('change', this.codemirrorValueChanged);
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
-		this._currentCodemirrorValue = this.props.defaultValue || this.props.value || '';
-		this.codeMirror.setValue(this._currentCodemirrorValue);
+		this.codeMirror.setValue(this.props.defaultValue || this.props.value || '');
 	},
 	componentWillUnmount () {
 		// todo: is there a lighter-weight way to remove the cm instance?
@@ -36,8 +36,8 @@ const CodeMirror = React.createClass({
 			this.codeMirror.toTextArea();
 		}
 	},
-	componentWillReceiveProps (nextProps) {
-		if (this.codeMirror && nextProps.value !== undefined && this._currentCodemirrorValue !== nextProps.value) {
+	componentWillReceiveProps = _.debounce(function(nextProps) {
+		if (this.codeMirror && nextProps.value !== undefined && this.codeMirror.getValue() != nextProps.value) {
 			this.codeMirror.setValue(nextProps.value);
 		}
 		if (typeof nextProps.options === 'object') {
@@ -47,7 +47,7 @@ const CodeMirror = React.createClass({
 				}
 			}
 		}
-	},
+	}, 0),
 	getCodeMirror () {
 		return this.codeMirror;
 	},
@@ -63,9 +63,9 @@ const CodeMirror = React.createClass({
 		this.props.onFocusChange && this.props.onFocusChange(focused);
 	},
 	codemirrorValueChanged (doc, change) {
-		const newValue = doc.getValue();
-		this._currentCodemirrorValue = newValue;
-		this.props.onChange && this.props.onChange(newValue);
+		if (this.props.onChange && change.origin != 'setValue') {
+			this.props.onChange(doc.getValue());
+		}
 	},
 	render () {
 		const editorClassName = className(


### PR DESCRIPTION
There is duplication of state between the original CodeMirror object and the CodeMirror react component. Synchronization between the two is buggy. In addition, the client app usually keeps their own code state, and passes it in via the `value` attribute. This also creates bugs. See an example here: https://jsfiddle.net/n1gz4hLn/1/

This change (a) removes the redundant state from the React component and (b) debounces the `componentWillReceiveProps` function. The debounce has the effect of limiting the number of calls to the internal `codeMirror.setValue` function, which when called too often can screw up internal CodeMirror state (like the position of the cursor).