### PR TITLE
adding onScroll event

### DIFF
--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -6,6 +6,7 @@ const CodeMirror = React.createClass({
 	propTypes: {
 		onChange: React.PropTypes.func,
 		onFocusChange: React.PropTypes.func,
+		onScroll: React.PropTypes.func,
 		options: React.PropTypes.object,
 		path: React.PropTypes.string,
 		value: React.PropTypes.string,
@@ -27,6 +28,7 @@ const CodeMirror = React.createClass({
 		this.codeMirror.on('change', this.codemirrorValueChanged);
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
+		this.codeMirror.on('scroll', this.scrollChanged);
 		this.codeMirror.setValue(this.props.defaultValue || this.props.value || '');
 	},
 	componentWillUnmount () {
@@ -60,6 +62,9 @@ const CodeMirror = React.createClass({
 			isFocused: focused,
 		});
 		this.props.onFocusChange && this.props.onFocusChange(focused);
+	},
+	scrollChanged(cm) {
+		this.props.onScroll && this.props.onScroll(cm.getScrollInfo());
 	},
 	codemirrorValueChanged (doc, change) {
 		if (this.props.onChange && change.origin != 'setValue') {


### PR DESCRIPTION
Hi,

Thanks for the good work on this component. I added the onScroll event, i needed this to detect and synchronize scrolling between CodeMirror textarea and a preview pane for a project i am working on.

It's using CodeMirror `getScrollInfo` :
> cm.getScrollInfo() → {left, top, width, height, clientWidth, clientHeight}
Get an {left, top, width, height, clientWidth, clientHeight} object that represents the current scroll position, the size of the scrollable area, and the size of the visible area (minus scrollbars).

