### PR TITLE
Make debounce specific to the instance

### DIFF
--- a/lib/Codemirror.js
+++ b/lib/Codemirror.js
@@ -10,6 +10,7 @@ var CodeMirror = React.createClass({
 	propTypes: {
 		onChange: React.PropTypes.func,
 		onFocusChange: React.PropTypes.func,
+		onScroll: React.PropTypes.func,
 		options: React.PropTypes.object,
 		path: React.PropTypes.string,
 		value: React.PropTypes.string,
@@ -25,13 +26,26 @@ var CodeMirror = React.createClass({
 		};
 	},
 	componentDidMount: function componentDidMount() {
-		var textareaNode = this.refs.textarea;
+		var textareaNode = this.textarea;
 		var codeMirrorInstance = this.getCodeMirrorInstance();
 		this.codeMirror = codeMirrorInstance.fromTextArea(textareaNode, this.props.options);
 		this.codeMirror.on('change', this.codemirrorValueChanged);
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
+		this.codeMirror.on('scroll', this.scrollChanged);
 		this.codeMirror.setValue(this.props.defaultValue || this.props.value || '');
+		this.updateProps = debounce(function (nextProps) {
+			if (this.codeMirror && nextProps.value !== undefined && this.codeMirror.getValue() != nextProps.value) {
+				this.codeMirror.setValue(nextProps.value);
+			}
+			if (typeof nextProps.options === 'object') {
+				for (var optionName in nextProps.options) {
+					if (nextProps.options.hasOwnProperty(optionName)) {
+						this.codeMirror.setOption(optionName, nextProps.options[optionName]);
+					}
+				}
+			}
+		}, 0);
 	},
 	componentWillUnmount: function componentWillUnmount() {
 		// is there a lighter-weight way to remove the cm instance?
@@ -39,18 +53,9 @@ var CodeMirror = React.createClass({
 			this.codeMirror.toTextArea();
 		}
 	},
-	componentWillReceiveProps: debounce(function (nextProps) {
-		if (this.codeMirror && nextProps.value !== undefined && this.codeMirror.getValue() != nextProps.value) {
-			this.codeMirror.setValue(nextProps.value);
-		}
-		if (typeof nextProps.options === 'object') {
-			for (var optionName in nextProps.options) {
-				if (nextProps.options.hasOwnProperty(optionName)) {
-					this.codeMirror.setOption(optionName, nextProps.options[optionName]);
-				}
-			}
-		}
-	}, 0),
+	componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
+		this.updateProps(nextProps);
+	},
 	getCodeMirror: function getCodeMirror() {
 		return this.codeMirror;
 	},
@@ -65,17 +70,24 @@ var CodeMirror = React.createClass({
 		});
 		this.props.onFocusChange && this.props.onFocusChange(focused);
 	},
+	scrollChanged: function scrollChanged(cm) {
+		this.props.onScroll && this.props.onScroll(cm.getScrollInfo());
+	},
 	codemirrorValueChanged: function codemirrorValueChanged(doc, change) {
 		if (this.props.onChange && change.origin != 'setValue') {
 			this.props.onChange(doc.getValue());
 		}
 	},
 	render: function render() {
+		var _this = this;
+
 		var editorClassName = className('ReactCodeMirror', this.state.isFocused ? 'ReactCodeMirror--focused' : null, this.props.className);
 		return React.createElement(
 			'div',
 			{ className: editorClassName },
-			React.createElement('textarea', { ref: 'textarea', name: this.props.path, defaultValue: this.props.value, autoComplete: 'off' })
+			React.createElement('textarea', { ref: function (node) {
+					return _this.textarea = node;
+				}, name: this.props.path, defaultValue: this.props.value, autoComplete: 'off' })
 		);
 	}
 });

--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -22,14 +22,26 @@ const CodeMirror = React.createClass({
 		};
 	},
 	componentDidMount () {
-		const textareaNode = this.refs.textarea;
+		const textareaNode = this.textarea;
 		const codeMirrorInstance = this.getCodeMirrorInstance();
-		this.codeMirror = codeMirrorInstance.fromTextArea(textareaNode, this.props.options);
+		this.codeMirror = codeMirrorInstance.fromTextArea(textareaNode.value, this.props.options);
 		this.codeMirror.on('change', this.codemirrorValueChanged);
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
 		this.codeMirror.on('scroll', this.scrollChanged);
 		this.codeMirror.setValue(this.props.defaultValue || this.props.value || '');
+    this.updateProps = debounce(function (nextProps) {
+      if (this.codeMirror && nextProps.value !== undefined && this.codeMirror.getValue() != nextProps.value) {
+        this.codeMirror.setValue(nextProps.value);
+      }
+      if (typeof nextProps.options === 'object') {
+        for (let optionName in nextProps.options) {
+          if (nextProps.options.hasOwnProperty(optionName)) {
+            this.codeMirror.setOption(optionName, nextProps.options[optionName]);
+          }
+        }
+      }
+    }, 0);
 	},
 	componentWillUnmount () {
 		// is there a lighter-weight way to remove the cm instance?
@@ -37,18 +49,9 @@ const CodeMirror = React.createClass({
 			this.codeMirror.toTextArea();
 		}
 	},
-	componentWillReceiveProps: debounce(function (nextProps) {
-		if (this.codeMirror && nextProps.value !== undefined && this.codeMirror.getValue() != nextProps.value) {
-			this.codeMirror.setValue(nextProps.value);
-		}
-		if (typeof nextProps.options === 'object') {
-			for (let optionName in nextProps.options) {
-				if (nextProps.options.hasOwnProperty(optionName)) {
-					this.codeMirror.setOption(optionName, nextProps.options[optionName]);
-				}
-			}
-		}
-	}, 0),
+	componentWillReceiveProps: function (nextProps) {
+    this.updateProps(nextProps);
+	},
 	getCodeMirror () {
 		return this.codeMirror;
 	},
@@ -79,7 +82,7 @@ const CodeMirror = React.createClass({
 		);
 		return (
 			<div className={editorClassName}>
-				<textarea ref="textarea" name={this.props.path} defaultValue={this.props.value} autoComplete="off" />
+        <textarea ref={(node) => this.textarea = node} name={this.props.path} defaultValue={this.props.value} autoComplete="off" />
 			</div>
 		);
 	},


### PR DESCRIPTION
Solution to #47, ensures that the `debounce` is applied at the instance level. The way it is currently written, all instances of this component are sharing the same `debounce` so only one instance will update when multiple instances on a page are supposed to update simultaneously. This is an issue for things like drag & drop sorting of codemirror content blocks.