### PR TITLE
Also use React.PropTypes.func in lib/

### DIFF
--- a/lib/Codemirror.js
+++ b/lib/Codemirror.js
@@ -14,7 +14,7 @@ var CodeMirror = React.createClass({
 		path: React.PropTypes.string,
 		value: React.PropTypes.string,
 		className: React.PropTypes.any,
-		codeMirrorInstance: React.PropTypes.object
+		codeMirrorInstance: React.PropTypes.func
 	},
 	getCodeMirrorInstance: function getCodeMirrorInstance() {
 		return this.props.codeMirrorInstance || require('codemirror');


### PR DESCRIPTION
This is a follow-on to #54 -- we also need to change the type specification inside `lib/`