### PR TITLE
Pass style object to containing div and formatted readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ You can interact with the CodeMirror instance using a `ref` and the `getCodeMirr
 
 ### Properties
 
-* `autoSave` `Boolean` automatically persist changes to underlying textarea (default false)
-* `value` `String` the editor value
-* `options` `Object (newValue)` options passed to the CodeMirror instance
-* `onChange` `Function (newValue)` called when a change is made
-* `onFocusChange` `Function (focused)` called when the editor is focused or loses focus
+| Name | Type | Description |
+|------|------|-------------|
+| `autoSave` | `Boolean` | Automatically persist changes to underlying textarea (default false) |
+| `value` | `String` | The editor value |
+| `options` | `Object (newValue)` | Options passed to the CodeMirror instance |
+| `onChange` | `Function (newValue)` | Called when a change is made |
+| `onFocusChange` | `Function (focused)` | Called when the editor is focused or loses focus |
+| `onScroll` | `Function (scrollInfo)` | Called when the editor is scrolled with a [scrollInfo](https://codemirror.net/doc/manual.html#getScrollInfo) object |
 
 See the [CodeMirror API Docs](https://codemirror.net/doc/manual.html#api) for the available options.
 

--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -11,6 +11,7 @@ const CodeMirror = React.createClass({
 		path: React.PropTypes.string,
 		value: React.PropTypes.string,
 		className: React.PropTypes.any,
+		style: React.PropTypes.object,
 		codeMirrorInstance: React.PropTypes.func,
 	},
 	getCodeMirrorInstance () {
@@ -78,7 +79,7 @@ const CodeMirror = React.createClass({
 			this.props.className
 		);
 		return (
-			<div className={editorClassName}>
+			<div className={editorClassName} style={this.props.style}>
 				<textarea ref="textarea" name={this.props.path} defaultValue={this.props.value} autoComplete="off" />
 			</div>
 		);


### PR DESCRIPTION
Hi,

I wanted to pass some style options to the containing div, I could just wrap it within another div, but wanted to keep things clean.

For example, this allows us to add a red border around it when the editor value is changed.

```javascript
// Before: (Div inside a Div with code mirror inside)
<div style={boxStyles.bordered.editor}>
    <Codemirror/>
</div>


// After - Apply styles directly on the `.ReactCodeMirror` element
<Codemirror
    ref="editor"
    value={this.state.code}
    onChange={this.updateCode}
    options={options}
    interact={this.interact}
    onScroll={this.scrolled} // New! - on master (not from me - but unreleased)
    style={boxStyles.bordered.editor} // New!
/>
```

I also updated the README to format the properties into a table for easy reading and added the _unreleased_ scroll event.

Can we have these merged and tag a new version (0.2.7) with the scroll event and the passing of the style prop?

Requires a `npm run build`, for the 2 new features on master (scroll and style prop).

Thanks!