### PR TITLE
Use React DOM Polyfill to support React 0.12+

### DIFF
--- a/lib/Codemirror.js
+++ b/lib/Codemirror.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var React = require('react');
+var ReactDOM = require('react-dom-polyfill')(React);
+var findDOMNode = ReactDOM.findDOMNode;
 var className = require('classnames');
 var debounce = require('lodash.debounce');
 
@@ -10,11 +12,12 @@ var CodeMirror = React.createClass({
 	propTypes: {
 		onChange: React.PropTypes.func,
 		onFocusChange: React.PropTypes.func,
+		onScroll: React.PropTypes.func,
 		options: React.PropTypes.object,
 		path: React.PropTypes.string,
 		value: React.PropTypes.string,
 		className: React.PropTypes.any,
-		codeMirrorInstance: React.PropTypes.object
+		codeMirrorInstance: React.PropTypes.func
 	},
 	getCodeMirrorInstance: function getCodeMirrorInstance() {
 		return this.props.codeMirrorInstance || require('codemirror');
@@ -25,12 +28,13 @@ var CodeMirror = React.createClass({
 		};
 	},
 	componentDidMount: function componentDidMount() {
-		var textareaNode = this.refs.textarea;
+		var textareaNode = findDOMNode(this.refs.textarea);
 		var codeMirrorInstance = this.getCodeMirrorInstance();
 		this.codeMirror = codeMirrorInstance.fromTextArea(textareaNode, this.props.options);
 		this.codeMirror.on('change', this.codemirrorValueChanged);
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
+		this.codeMirror.on('scroll', this.scrollChanged);
 		this.codeMirror.setValue(this.props.defaultValue || this.props.value || '');
 	},
 	componentWillUnmount: function componentWillUnmount() {
@@ -64,6 +68,9 @@ var CodeMirror = React.createClass({
 			isFocused: focused
 		});
 		this.props.onFocusChange && this.props.onFocusChange(focused);
+	},
+	scrollChanged: function scrollChanged(cm) {
+		this.props.onScroll && this.props.onScroll(cm.getScrollInfo());
 	},
 	codemirrorValueChanged: function codemirrorValueChanged(doc, change) {
 		if (this.props.onChange && change.origin != 'setValue') {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,14 @@
     "happiness": "^1.0.7",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
-    "react-component-gulp-tasks": "^0.7.7"
+    "react-component-gulp-tasks": "^0.7.7",
+    "react-dom-polyfill": "^1.0.0-beta.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": ">=0.12 <16"
+  },
+  "optionalDependencies": {
+    "react-dom": "<16"
   },
   "browserify-shim": {
     "react": "global:React"

--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -1,4 +1,6 @@
 const React = require('react');
+const ReactDOM = require('react-dom-polyfill')(React);
+const findDOMNode = ReactDOM.findDOMNode;
 const className = require('classnames');
 const debounce = require('lodash.debounce');
 
@@ -22,7 +24,7 @@ const CodeMirror = React.createClass({
 		};
 	},
 	componentDidMount () {
-		const textareaNode = this.refs.textarea;
+		const textareaNode = findDOMNode(this.refs.textarea);
 		const codeMirrorInstance = this.getCodeMirrorInstance();
 		this.codeMirror = codeMirrorInstance.fromTextArea(textareaNode, this.props.options);
 		this.codeMirror.on('change', this.codemirrorValueChanged);


### PR DESCRIPTION
React DOM Polyfill is a tiny wrapper for ReactDOM. It allows projects to publish builds that work with new & old React versions at the same time. For 0.14+ it simply proxies ReactDOM, while in 0.12-0.14 it interfaces the old React methods with the new ReactDOM API. Read more at https://github.com/skidding/react-cosmos/tree/master/packages/react-dom-polyfill.

We're using React CodeMirror in the upcoming [React Cosmos](https://github.com/skidding/react-cosmos) v1.0 release. We recently incorporated React DOM Polyfill to make React Cosmos available for a large codebase still using React 0.13. Right now we're using a React CodeMirror fork as a dependency, but it would be great if we could incorporate this upstream and benefit both projects. 

Looking forward to hear thoughts on this. Thanks!

*PS. The other `lib` changes were due to previous contributions that only updated the source.*