### PR TITLE
Remove react-dom from optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
   "peerDependencies": {
     "react": ">=0.12 <16"
   },
-  "optionalDependencies": {
-    "react-dom": "<16"
-  },
   "browserify-shim": {
     "react": "global:React"
   },


### PR DESCRIPTION
@JedWatson I committed an error in my previous PR #64

While my PR made `react-codemirror` work with older Reacts, because of this `optionalDependencies` entry npm kept screaming that `react-dom` is missing in those cases.

I read the [npm doc](https://docs.npmjs.com/files/package.json#optionaldependencies) again and it seems *optionalDependencies* is more tied to *dependencies* than *peerDependencies* (which is were `react` & `react-dom` usually belong), so it seems like the cleanest thing to do is to omit it altogether. After all, it was missing before my PR and all was good.

PS. When do you think there'll be an npm release with the latest master?

Thanks!