### PR TITLE
make the need for codemirror.css explicit in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ You can also use the standalone build by including `dist/react-codemirror.js` in
 npm install react-codemirror --save
 ```
 
+Ensure that ``codemirror.css`` is loaded. It can be included in your module css as shown in [example.less](example/src/example.less) or linked explicitly in your index.html file e.g ``<link href="css/codemirror.css"  rel="stylesheet">``.
+
 
 ## Usage
 


### PR DESCRIPTION
I spent a while wondering why the pasted in example code did not 'just work' until I remembered I needed to explicitly include the codemirror.css file.

Making this explicit in the readme will hopefully save some other users time when they make use of this excellent module.