### PR TITLE
Added browserify-optional; failed with missing module on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/JedWatson/react-codemirror/issues"
   },
   "dependencies": {
+    "browserify-optional": "^1.0.0",
     "classnames": "^2.2.5",
     "codemirror": "^5.18.2",
     "lodash.debounce": "^4.0.8"


### PR DESCRIPTION
When running `npm start`, got this error that browserify-optional was missing:

```
Browserify Error { Error: Cannot find module 'browserify-optional' from '/home/jpeabody/piper/mergely-dev/react-codemirror/node_modules/react-dom-polyfill'
    at /home/jpeabody/piper/mergely-dev/react-codemirror/node_modules/resolve/lib/async.js:46:17
    at process (/home/jpeabody/piper/mergely-dev/react-codemirror/node_modules/resolve/lib/async.js:173:43)
    at ondir (/home/jpeabody/piper/mergely-dev/react-codemirror/node_modules/resolve/lib/async.js:188:17)
    at load (/home/jpeabody/piper/mergely-dev/react-codemirror/node_modules/resolve/lib/async.js:69:43)
    at onex (/home/jpeabody/piper/mergely-dev/react-codemirror/node_modules/resolve/lib/async.js:92:31)
    at /home/jpeabody/piper/mergely-dev/react-codemirror/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:117:15)
```
