### PR TITLE
Don't call setValue in componentDidMount

### DIFF
--- a/lib/Codemirror.js
+++ b/lib/Codemirror.js
@@ -50,7 +50,6 @@ var CodeMirror = React.createClass({
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
 		this.codeMirror.on('scroll', this.scrollChanged);
-		this.codeMirror.setValue(this.props.defaultValue || this.props.value || '');
 	},
 	componentWillUnmount: function componentWillUnmount() {
 		// is there a lighter-weight way to remove the cm instance?

--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -46,7 +46,6 @@ const CodeMirror = React.createClass({
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
 		this.codeMirror.on('scroll', this.scrollChanged);
-		this.codeMirror.setValue(this.props.defaultValue || this.props.value || '');
 	},
 	componentWillUnmount () {
 		// is there a lighter-weight way to remove the cm instance?


### PR DESCRIPTION
...since it causes unwanted scroll into codemirror textarea.

To reproduce problem:
* add a bunch of line breaks to example html, so that Codemirror textarea is rendered outside of visible viewport area
* render Codemirror not immediately, but after some time the example component is mounted (for instance setTimeout in example.js's `componentDidMount`, and check in render method, if "doRender" is false, don't create Codemirror)

This change doesn't seem to affect anything; value is still set (without scroll, for whatever reason) in `componentWillReceiveProps`.