### PR TITLE
Fixed React 15.5 deprecation warnings

### DIFF
--- a/example/src/example.js
+++ b/example/src/example.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var Codemirror = require('../../src/Codemirror');
+const createReactClass = require('create-react-class');
 
 require('codemirror/mode/javascript/javascript');
 require('codemirror/mode/xml/xml');
@@ -11,7 +12,7 @@ var defaults = {
 	javascript: 'var component = {\n\tname: "react-codemirror",\n\tauthor: "Jed Watson",\n\trepo: "https://github.com/JedWatson/react-codemirror"\n};'
 };
 
-var App = React.createClass({
+var App = createReactClass({
 	getInitialState () {
 		return {
 			code: defaults.markdown,

--- a/package.json
+++ b/package.json
@@ -16,18 +16,20 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "codemirror": "^5.18.2",
-    "lodash.debounce": "^4.0.8"
+    "create-react-class": "^15.5.1",
+    "lodash.debounce": "^4.0.8",
+    "prop-types": "^15.5.4"
   },
   "devDependencies": {
     "gulp": "^3.9.1",
     "happiness": "^7.1.2",
-    "react": "^15.3.1",
-    "react-dom": "^15.3.1",
+    "react": "^15.5.3",
+    "react-dom": "^15.5.3",
     "react-component-gulp-tasks": "^0.7.7"
   },
   "peerDependencies": {
-    "react": ">=0.14 <16",
-    "react-dom": ">=0.14 <16"
+    "react": ">=15.5 <16",
+    "react-dom": ">=15.5 <16"
   },
   "browserify-shim": {
     "react": "global:React"

--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -1,26 +1,28 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 const findDOMNode = ReactDOM.findDOMNode;
+const PropTypes = require('prop-types');
 const className = require('classnames');
 const debounce = require('lodash.debounce');
+const createReactClass = require('create-react-class');
 
 function normalizeLineEndings (str) {
 	if (!str) return str;
 	return str.replace(/\r\n|\r/g, '\n');
 }
 
-const CodeMirror = React.createClass({
+const CodeMirror = createReactClass({
 	propTypes: {
-		className: React.PropTypes.any,
-		codeMirrorInstance: React.PropTypes.func,
-		defaultValue: React.PropTypes.string,
-		onChange: React.PropTypes.func,
-		onFocusChange: React.PropTypes.func,
-		onScroll: React.PropTypes.func,
-		options: React.PropTypes.object,
-		path: React.PropTypes.string,
-		value: React.PropTypes.string,
-		preserveScrollPosition: React.PropTypes.bool,
+		className: PropTypes.any,
+		codeMirrorInstance: PropTypes.func,
+		defaultValue: PropTypes.string,
+		onChange: PropTypes.func,
+		onFocusChange: PropTypes.func,
+		onScroll: PropTypes.func,
+		options: PropTypes.object,
+		path: PropTypes.string,
+		value: PropTypes.string,
+		preserveScrollPosition: PropTypes.bool,
 	},
 	getDefaultProps () {
 		return {


### PR DESCRIPTION
For your consideration.

1. Replaced `React.PropTypes` with [`prop-types` module](https://www.npmjs.com/package/prop-types). See [React 15.5 release notes](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes).
1. Replaced `React.createClass` with [`create-react-class` module](https://www.npmjs.com/package/create-react-class). See [React 15.5 release notes](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.createclass).

This commit changes the peer dependency requirement to 15.3+ in order to avoid introducing the following _new_ warning:
> Warning: You are manually calling a React.PropTypes validation function for the `className` prop on `<<anonymous>>`. This is deprecated and will not work in production with the next major version. You may be seeing this warning due to a third-party PropTypes library. See https://fb.me/react-warning-dont-call-proptypes for details.