### PR TITLE
update code to prevent react deprecation errors

### DIFF
--- a/example/src/example.js
+++ b/example/src/example.js
@@ -1,7 +1,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 var Codemirror = require('../../src/Codemirror');
-
+var createReactClass = require('create-react-class');
 require('codemirror/mode/javascript/javascript');
 require('codemirror/mode/xml/xml');
 require('codemirror/mode/markdown/markdown');
@@ -11,7 +11,7 @@ var defaults = {
 	javascript: 'var component = {\n\tname: "react-codemirror",\n\tauthor: "Jed Watson",\n\trepo: "https://github.com/JedWatson/react-codemirror"\n};'
 };
 
-var App = React.createClass({
+var App = createReactClass({
 	getInitialState () {
 		return {
 			code: defaults.markdown,

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "codemirror": "^5.18.2",
-    "lodash.debounce": "^4.0.8"
+    "lodash.debounce": "^4.0.8",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "gulp": "^3.9.1",
     "happiness": "^7.1.2",
     "react": "^15.3.1",
-    "react-dom": "^15.3.1",
-    "react-component-gulp-tasks": "^0.7.7"
+    "react-component-gulp-tasks": "^0.7.7",
+    "react-dom": "^15.3.1"
   },
   "peerDependencies": {
     "react": ">=0.14 <16",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "codemirror": "^5.18.2",
+    "create-react-class": "^15.5.2",
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.5.8"
   },

--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -2,6 +2,7 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const findDOMNode = ReactDOM.findDOMNode;
 const PropTypes = require('prop-types'); 
+const createReactClass = require('create-react-class');
 const className = require('classnames');
 const debounce = require('lodash.debounce');
 
@@ -10,7 +11,7 @@ function normalizeLineEndings (str) {
 	return str.replace(/\r\n|\r/g, '\n');
 }
 
-const CodeMirror = React.createClass({
+const CodeMirror = createReactClass({
 	propTypes: {
 		className: PropTypes.any,
 		codeMirrorInstance: PropTypes.func,

--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -1,6 +1,7 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 const findDOMNode = ReactDOM.findDOMNode;
+const PropTypes = require('prop-types'); 
 const className = require('classnames');
 const debounce = require('lodash.debounce');
 
@@ -11,16 +12,16 @@ function normalizeLineEndings (str) {
 
 const CodeMirror = React.createClass({
 	propTypes: {
-		className: React.PropTypes.any,
-		codeMirrorInstance: React.PropTypes.func,
-		defaultValue: React.PropTypes.string,
-		onChange: React.PropTypes.func,
-		onFocusChange: React.PropTypes.func,
-		onScroll: React.PropTypes.func,
-		options: React.PropTypes.object,
-		path: React.PropTypes.string,
-		value: React.PropTypes.string,
-		preserveScrollPosition: React.PropTypes.bool,
+		className: PropTypes.any,
+		codeMirrorInstance: PropTypes.func,
+		defaultValue: PropTypes.string,
+		onChange: PropTypes.func,
+		onFocusChange: PropTypes.func,
+		onScroll: PropTypes.func,
+		options: PropTypes.object,
+		path: PropTypes.string,
+		value: PropTypes.string,
+		preserveScrollPosition: PropTypes.bool,
 	},
 	getDefaultProps () {
 		return {


### PR DESCRIPTION
Due to [React.PropTypes](https://facebook.github.io/react/docs/typechecking-with-proptypes.html) being deprecated as of React v15.5 and it is recommended to use the prop-types library instead. 

To prevent errors and warnings being shown in the console I have added both prop-types and [create-react-class]( https://www.npmjs.com/package/create-react-class). More information on `create-react-class` can be [seen here](https://facebook.github.io/react/docs/react-without-es6.html).