### PR TITLE
Only update value if props.value has changed

### DIFF
--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -55,7 +55,7 @@ const CodeMirror = React.createClass({
 		}
 	},
 	componentWillReceiveProps: function (nextProps) {
-		if (this.codeMirror && nextProps.value !== undefined && normalizeLineEndings(this.codeMirror.getValue()) !== normalizeLineEndings(nextProps.value)) {
+		if (this.codeMirror && nextProps.value !== undefined && nextProps.value !== this.props.value && normalizeLineEndings(this.codeMirror.getValue()) !== normalizeLineEndings(nextProps.value)) {
 			if (this.props.preserveScrollPosition) {
 				var prevScrollPosition = this.codeMirror.getScrollInfo();
 				this.codeMirror.setValue(nextProps.value);


### PR DESCRIPTION
`componentWillReceiveProps` updates the value in codeMirror (`this.codeMirror.setValue(nextProps.value)`) even if the value in the props has not changed (`nextProps.value`).   This means if the value in codeMirror has been changed, for example via the codeMirror API (e.g. `codeMirror.replaceRange()`), that new value is clobbered by the call to `componentWillReceiveProps` even though there is not a new value to set. 

In this PR, I check to see if the value in the props has changed and only update the value in codeMirror if it has changed. 