### PR TITLE
delete the comparison between the prop value with next prop value

### DIFF
--- a/lib/Codemirror.js
+++ b/lib/Codemirror.js
@@ -65,7 +65,7 @@ var CodeMirror = createReactClass({
 		}
 	},
 	componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
-		if (this.codeMirror && nextProps.value !== undefined && nextProps.value !== this.props.value && normalizeLineEndings(this.codeMirror.getValue()) !== normalizeLineEndings(nextProps.value)) {
+		if (this.codeMirror && nextProps.value !== undefined ) {
 			if (this.props.preserveScrollPosition) {
 				var prevScrollPosition = this.codeMirror.getScrollInfo();
 				this.codeMirror.setValue(nextProps.value);


### PR DESCRIPTION
In some case, we need to change editor code by javascript, In practise, the editor will never change the content if the comparison logic exits, because the value is consistent. With removing the logic code, change code is okay. U can practice with ur example.