### PR TITLE
add onKeyup handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ You can interact with the CodeMirror instance using a `ref` and the `getCodeMirr
 * `onCursorActivity` `Function (codemirror)` called when the cursor is moved
 * `onFocusChange` `Function (focused)` called when the editor is focused or loses focus
 * `onScroll` `Function (scrollInfo)` called when the editor is scrolled
+* `onKeyup` `Function ()` called on handling of keyup event
 * `preserveScrollPosition` `Boolean=false` preserve previous scroll position after updating value
 * `value` `String` the editor value
 

--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -22,6 +22,7 @@ const CodeMirror = createReactClass({
 		onCursorActivity: PropTypes.func,
 		onFocusChange: PropTypes.func,
 		onScroll: PropTypes.func,
+		onKeyup: PropTypes.func,
 		options: PropTypes.object,
 		path: PropTypes.string,
 		value: PropTypes.string,
@@ -54,6 +55,7 @@ const CodeMirror = createReactClass({
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
 		this.codeMirror.on('scroll', this.scrollChanged);
+		this.codeMirror.on('keyup', this.keyup.bind(this, true));
 		this.codeMirror.setValue(this.props.defaultValue || this.props.value || '');
 	},
 	componentWillUnmount () {
@@ -105,6 +107,9 @@ const CodeMirror = createReactClass({
 	},
 	scrollChanged (cm) {
 		this.props.onScroll && this.props.onScroll(cm.getScrollInfo());
+	},
+	keyup () {
+		this.props.onKeyup && this.props.onKeyup();
 	},
 	codemirrorValueChanged (doc, change) {
 		if (this.props.onChange && change.origin !== 'setValue') {


### PR DESCRIPTION
Adds prop handler for keyup event. Went with `onKeyup` since event is `keyup`, but I’d also be okay with  `onKeyUp` if preferred.

Primary goal for adding this is to be able to fire autocomplete on keyup event, as mentioned in #52 and #80.

Let me know if there’s anything I can do to assist getting this merged. 

Thanks for the work on this library!