### PR TITLE
Update README.md and example to add changeObj parameter to onChange property

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ var App = React.createClass({
 			code: "// Code",
 		};
 	},
-	updateCode: function(newCode) {
+	updateCode: function(newCode, changeObj) {
 		this.setState({
 			code: newCode,
 		});
+		// get changed valued from changeObj
 	},
 	render: function() {
 		var options = {
@@ -92,7 +93,7 @@ You can interact with the CodeMirror instance using a `ref` and the `getCodeMirr
 * `defaultValue` `String` provides a default (not change tracked) value to the editor
 * `name` `String` sets the name of the editor input field
 * `options` `Object` options passed to the CodeMirror instance
-* `onChange` `Function (newValue)` called when a change is made
+* `onChange` `Function (newValue, changeObj)` called when a change is made (`changeObj` is the object returned from [CodeMirror Change Event](https://codemirror.net/doc/manual.html#events))
 * `onCursorActivity` `Function (codemirror)` called when the cursor is moved
 * `onFocusChange` `Function (focused)` called when the editor is focused or loses focus
 * `onScroll` `Function (scrollInfo)` called when the editor is scrolled

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ var App = React.createClass({
 		this.setState({
 			code: newCode,
 		});
-		// get changed valued from changeObj
+		// get changed value from changeObj
+		console.log(changeObj);
 	},
 	render: function() {
 		var options = {

--- a/example/src/example.js
+++ b/example/src/example.js
@@ -20,10 +20,11 @@ var App = createReactClass({
 			mode: 'markdown',
 		};
 	},
-	updateCode (newCode) {
+	updateCode (newCode, changeObj) {
 		this.setState({
 			code: newCode
 		});
+		console.log(changeObj);
 	},
 	changeMode (e) {
 		var mode = e.target.value;


### PR DESCRIPTION
I read `React-CodeMirror`'s source code and found that the `onChange` property actually has 2 return values, i.e, `newCode` and `changeObj`, instead of the only one `newCode` in the current document. With `changeObj` programmers can do more elaborate work (eg, emitting event of changed values instead of the whole trunk of new code). I regard it worthwhile to document this second parameter to give programmers more choices.