### PR TITLE
Check next props value against code mirror value

### DIFF
--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -63,7 +63,7 @@ const CodeMirror = createReactClass({
 		}
 	},
 	componentWillReceiveProps: function (nextProps) {
-		if (this.codeMirror && nextProps.value !== undefined && nextProps.value !== this.props.value && normalizeLineEndings(this.codeMirror.getValue()) !== normalizeLineEndings(nextProps.value)) {
+		if (this.codeMirror && nextProps.value !== undefined && nextProps.value !== this.codeMirror.getValue() && normalizeLineEndings(this.codeMirror.getValue()) !== normalizeLineEndings(nextProps.value)) {
 			if (this.props.preserveScrollPosition) {
 				var prevScrollPosition = this.codeMirror.getScrollInfo();
 				this.codeMirror.setValue(nextProps.value);


### PR DESCRIPTION
We we having the same issues as described in https://github.com/JedWatson/react-codemirror/issues/121 and https://github.com/JedWatson/react-codemirror/issues/106. In our case, simply checking the next prop's value against the current code mirror value resolved the issue.