### PR TITLE
Bump react react-dom peerDependency to allow React v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "react-dom": "^15.5.3"
   },
   "peerDependencies": {
-    "react": ">=15.5 <16",
-    "react-dom": ">=15.5 <16"
+    "react": ">=15.5 || ^16",
+    "react-dom": ">=15.5 || ^16"
   },
   "browserify-shim": {
     "react": "global:React"

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "devDependencies": {
     "gulp": "^3.9.1",
     "happiness": "^7.1.2",
-    "react": "^15.5.3",
+    "react": "16.5.0",
     "react-component-gulp-tasks": "^0.7.7",
-    "react-dom": "^15.5.3"
+    "react-dom": "16.5.0"
   },
   "peerDependencies": {
     "react": ">=15.5 || ^16",


### PR DESCRIPTION
Small change to the package.json peerDependencies to allow React v16. This keeps the `>=15.5` constraint as well so current users won't need to upgrade and shouldn't have any issues.

Looking through to code I don't see any changes that need to be made for the upgrade -- it's working locally on my codebase.