### PR TITLE
pass through style

### DIFF
--- a/src/Codemirror.js
+++ b/src/Codemirror.js
@@ -15,6 +15,7 @@ const CodeMirror = createReactClass({
 	propTypes: {
 		autoFocus: PropTypes.bool,
 		className: PropTypes.any,
+		style: PropTypes.object,
 		codeMirrorInstance: PropTypes.func,
 		defaultValue: PropTypes.string,
 		name: PropTypes.string,
@@ -118,7 +119,7 @@ const CodeMirror = createReactClass({
 			this.props.className
 		);
 		return (
-			<div className={editorClassName}>
+			<div className={editorClassName} style={this.props.style}>
 				<textarea
 					ref={ref => this.textareaNode = ref}
 					name={this.props.name || this.props.path}


### PR DESCRIPTION
components should pass through their style properties so they can be used with higher order components like react-dimensions, or just doing custom styling.