### PR TITLE
Fixed a bug in CodeMirror component lifecycle

### DIFF
--- a/lib/Codemirror.js
+++ b/lib/Codemirror.js
@@ -4,7 +4,6 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var PropTypes = require('prop-types');
 var className = require('classnames');
-var debounce = require('lodash.debounce');
 var isEqual = require('lodash.isequal');
 var createReactClass = require('create-react-class');
 
@@ -43,7 +42,6 @@ var CodeMirror = createReactClass({
 		};
 	},
 	componentWillMount: function componentWillMount() {
-		this.componentWillReceiveProps = debounce(this.componentWillReceiveProps, 0);
 		if (this.props.path) {
 			console.error('Warning: react-codemirror: the `path` prop has been changed to `name`');
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-codemirror",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Codemirror",
   "main": "lib/Codemirror.js",
   "author": "Jed Watson",
@@ -17,7 +17,6 @@
     "classnames": "^2.2.5",
     "codemirror": "^5.18.2",
     "create-react-class": "^15.5.1",
-    "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.5.4"
   },


### PR DESCRIPTION
What I expect to happen:
* first componentWillUpdate is called, such that old and new props are different
* then render() is called with the new props, if componentShouldUpdate is true.

What actually happens:

* first render() is called with the new props.
* then componentWillUpdate is called such that old and new props are the same.

This is because debounce is deferring execution of
componentWillReceiveProps, thus breaking react component lifecycle
(which is described here:
https://busypeoples.github.io/post/react-component-lifecycle/).